### PR TITLE
Base.has_offset_axes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - osx
 julia:
   - 1.0
+  - 1.3
   - nightly
 matrix:
   allow_failures:

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,13 @@
 name = "BatchedRoutines"
 uuid = "8149b2a8-f11c-11e8-306d-59a25846b9b7"
 authors = ["Roger-luo <hiroger@qq.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[compat]
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 1.0
-CUDAapi

--- a/src/blas.jl
+++ b/src/blas.jl
@@ -34,7 +34,7 @@ for (fname, elty, lib) in ((:dsyr_,:Float64,libblas),
     (:csyr_,:ComplexF32,liblapack))
     @eval begin
         function batched_syr!(uplo::AbstractChar, α::$elty, x::AbstractArray{$elty, 2}, A::AbstractArray{$elty, 3})
-            @assert !has_offset_axes(A, x)
+            @assert !Base.has_offset_axes(A, x)
             n = checksquare(A)
             if length(x) != n
             throw(DimensionMismatch("A has size ($n,$n), x has length $(length(x))"))
@@ -57,7 +57,7 @@ for (fname, elty, relty) in ((:zher_,:ComplexF64, :Float64),
                              (:cher_,:ComplexF32, :Float32))
     @eval begin
         function batched_her!(uplo::AbstractChar, α::$relty, x::AbstractMatrix{$elty}, A::AbstractArray{$elty, 3})
-            @assert !has_offset_axes(A, x)
+            @assert !Base.has_offset_axes(A, x)
             n = checksquare(A)
             if length(x) != n
                 throw(DimensionMismatch("A has size ($n,$n), x has length $(length(x))"))
@@ -107,8 +107,8 @@ for (gemm, elty) in
             transA::AbstractChar, transB::AbstractChar,
             alpha::($elty), A::AbstractArray{($elty), 3}, B::AbstractArray{($elty), 3},
             beta::($elty), C::AbstractArray{($elty), 3})
-        
-            @assert !BLAS.has_offset_axes(A, B, C)
+
+            @assert !Base.has_offset_axes(A, B, C)
             m = size(A, transA == 'N' ? 1 : 2)
             ka = size(A, transA == 'N' ? 2 : 1)
             kb = size(B, transB == 'N' ? 1 : 2)
@@ -126,7 +126,7 @@ for (gemm, elty) in
                      transA, transB, m, n,
                      ka, alpha, ptrA, max(1,stride(A,2)),
                      ptrB, max(1,stride(B,2)), beta, ptrC,
-                     max(1,stride(C,2)))    
+                     max(1,stride(C,2)))
             end
             return C
         end


### PR DESCRIPTION
Fixes tests on v1.3, where `BLAS.has_offset_axes` no longer seems to exist. 